### PR TITLE
176 java.lang.ClassCastException when a method accepts an array as a second argument

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -10,6 +10,7 @@
   * IBS.DESERIALIZATION.DEPTH.LIMIT : This value sets the maximum depth of the deserialization.
   * IBS.DESERIALIZATION.DATE.FORMAT : The format in which the date should be deserialized.
   * IBS.PLUGINS.PACKAGE : The package path in which the IBS should search for the plugins you write.
+* [#176 ClassCastException when the second call argument is an array](https://github.com/adobe/bridgeService/issues/176). We discovered a bug regarding arrays. Whenever the second argument was an array, we would get a ClassCastException.
 
 ## 2.11.16
 * **New Feature** [#3 Include an Assertion Feature](https://github.com/adobe/bridgeService/issues/3). We have now included the possibility for users to define assertions. This allows you to clarify accepted results for the call you make with the IBS.

--- a/bridgeService-data/src/main/java/com/adobe/campaign/tests/bridge/testdata/one/SimpleStaticMethods.java
+++ b/bridgeService-data/src/main/java/com/adobe/campaign/tests/bridge/testdata/one/SimpleStaticMethods.java
@@ -129,4 +129,5 @@ public class SimpleStaticMethods {
     public int methodAcceptingStringAndArray(String stringObject, String[] arrayObject) {
         return stringObject.length()+arrayObject.length;
     }
+
 }

--- a/bridgeService-data/src/main/java/com/adobe/campaign/tests/bridge/testdata/one/SimpleStaticMethods.java
+++ b/bridgeService-data/src/main/java/com/adobe/campaign/tests/bridge/testdata/one/SimpleStaticMethods.java
@@ -124,4 +124,9 @@ public class SimpleStaticMethods {
     public static String methodAcceptingFile(File fileObject) throws IOException {
         return Files.readString(fileObject.toPath(), StandardCharsets.UTF_8);
     }
+
+    //Issue #176
+    public int methodAcceptingStringAndArray(String stringObject, String[] arrayObject) {
+        return stringObject.length()+arrayObject.length;
+    }
 }

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/CallContent.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/CallContent.java
@@ -260,20 +260,24 @@ public class CallContent {
         return result;
     }
 
+
+
     /**
      * This method transforms the arguments, when necessary to the target objects
-     * @param in_objects
-     * @param in_method
-     * @return
+     * @param in_objects An array of argument objects
+     * @param in_method The method we want to call
+     * @return The transformed array of objects for execution purposes.
      */
-     Object[] castArgs(Object[] in_objects, Method in_method) {
+    Object[] castArgs(Object[] in_objects, Method in_method) {
         List<Object> ltr_objects =  new ArrayList<>();
         for (int i=0; i < in_objects.length; i++) {
             Class lt_type = in_method.getParameterTypes()[i];
+
+            //If object is an array
             if (lt_type.isArray() && in_objects[i] instanceof List) {
                 Class<?> lt_targetClass = lt_type.getComponentType();
-                Object lt_targetObject = Array.newInstance(lt_targetClass, ((List)in_objects[0]).size());
-                for (int i2=0; i2 < ((List)in_objects[0]).size(); i2++) {
+                Object lt_targetObject = Array.newInstance(lt_targetClass, ((List)in_objects[i]).size());
+                for (int i2=0; i2 < ((List)in_objects[i]).size(); i2++) {
                     Array.set(lt_targetObject, i2, ((List<?>) in_objects[i]).get(i2));
                 }
                 ltr_objects.add(lt_targetObject);
@@ -284,4 +288,5 @@ public class CallContent {
 
         return ltr_objects.toArray();
     }
+
 }

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/JavaCalls.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/JavaCalls.java
@@ -77,7 +77,7 @@ public class JavaCalls {
                 throw new JavaObjectInaccessibleException(e.getCause().getMessage(), e.getCause().getCause());
 
             } else {
-                throw new IBSRunTimeException(e.getMessage());
+                throw new IBSRunTimeException(e.getMessage(), e.getCause());
             }
 
         } catch (TimeoutException e) {

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/exceptions/IBSRunTimeException.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/exceptions/IBSRunTimeException.java
@@ -19,4 +19,8 @@ public class IBSRunTimeException extends RuntimeException {
     public IBSRunTimeException(String message) {
         super(message);
     }
+
+    public IBSRunTimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/E2ETests.java
+++ b/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/E2ETests.java
@@ -974,6 +974,7 @@ public class E2ETests {
                 Matchers.equalTo(5));
     }
 
+
     @AfterGroups(groups = "E2E", alwaysRun = true)
     public void tearDown() throws IOException {
 

--- a/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/E2ETests.java
+++ b/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/E2ETests.java
@@ -956,6 +956,24 @@ public class E2ETests {
 
     }
 
+
+    @Test(groups = "E2E")
+    public void testIssue176_classCastExceptionArrayFollowingString() throws IOException {
+
+        JavaCalls l_myJavaCall = new JavaCalls();
+
+        CallContent l_cc1 = new CallContent();
+        l_cc1.setClassName(SimpleStaticMethods.class.getTypeName());
+        l_cc1.setMethodName("methodAcceptingStringAndArray");
+        String[] l_array = new String[]{"value1", "value2"};
+        l_cc1.setArgs(new Object[]{"ASD", l_array});
+
+        l_myJavaCall.getCallContent().put("fetchResults", l_cc1);
+
+        given().body(l_myJavaCall).post(EndPointURL + "call").then().assertThat().statusCode(200).body("returnValues.fetchResults",
+                Matchers.equalTo(5));
+    }
+
     @AfterGroups(groups = "E2E", alwaysRun = true)
     public void tearDown() throws IOException {
 

--- a/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/TestFetchCalls.java
+++ b/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/TestFetchCalls.java
@@ -15,6 +15,8 @@ import com.adobe.campaign.tests.bridge.testdata.two.StaticMethodsIntegrity;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
@@ -2106,5 +2108,26 @@ public class TestFetchCalls {
                 fetchSubjects, Matchers.hasItem("a subject by me complexCallsArray_3"));
 
     }
+
+    @Test
+    public void issue176_callingMethodAcceptingStringAndArray() {
+        JavaCalls l_myJavaCall = new JavaCalls();
+
+        IntegroBridgeClassLoader iclCL = Mockito.mock(IntegroBridgeClassLoader.class);
+        l_myJavaCall.setLocalClassLoader(iclCL);
+
+        Mockito.when(iclCL.getCallResultCache()).thenThrow(new RuntimeException("We should not have called this method"));
+
+        CallContent l_cc1 = new CallContent();
+        l_cc1.setClassName(SimpleStaticMethods.class.getTypeName());
+        l_cc1.setMethodName("methodAcceptingStringAndArray");
+        String[] l_array = new String[]{"value1", "value2"};
+        l_cc1.setArgs(new Object[]{"ASD", l_array});
+
+        l_myJavaCall.getCallContent().put("fetchResults", l_cc1);
+
+        Assert.assertThrows(IBSRunTimeException.class, () ->  l_myJavaCall.submitCalls());
+    }
+
 }
 

--- a/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/TestFetchCalls.java
+++ b/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/TestFetchCalls.java
@@ -2068,5 +2068,24 @@ public class TestFetchCalls {
 
     }
 
+    @Test
+    public void issue176_callingMethodAcceptingStringAndArray() {
+        JavaCalls l_myJavaCall = new JavaCalls();
+
+        CallContent l_cc1 = new CallContent();
+        l_cc1.setClassName(SimpleStaticMethods.class.getTypeName());
+        l_cc1.setMethodName("methodAcceptingStringAndArray");
+        String[] l_array = new String[]{"value1", "value2"};
+        l_cc1.setArgs(new Object[]{"ASD", l_array});
+
+        l_myJavaCall.getCallContent().put("fetchResults", l_cc1);
+
+        JavaCallResults jcr = l_myJavaCall.submitCalls();
+
+        assertThat("we should have succeeded", jcr.getReturnValues().keySet(), Matchers.containsInAnyOrder("fetchResults"));
+
+
+    }
+
 }
 

--- a/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/TestFetchCalls.java
+++ b/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/TestFetchCalls.java
@@ -1998,6 +1998,45 @@ public class TestFetchCalls {
     }
 
     @Test
+    public void testInListToArrayTransformationBug176() throws NoSuchMethodException, ClassNotFoundException {
+        JavaCalls l_myJavaCall = new JavaCalls();
+
+        CallContent l_cc = new CallContent();
+        l_cc.setClassName(SimpleStaticMethods.class.getTypeName());
+        l_cc.setMethodName("methodAcceptingStringAndArray");
+        List<String> l_array = Arrays.asList("value1", "value2");
+        l_cc.setArgs(new Object[]{"ASD", l_array});
+        l_myJavaCall.getCallContent().put("call1", l_cc);
+
+        Method l_myMethod = SimpleStaticMethods.class.getDeclaredMethod(l_cc.getMethodName(), String.class, String[].class);
+        System.out.println(l_myMethod.getParameterTypes()[0]);
+        System.out.println(l_myMethod.getParameterTypes()[1]);
+        assertThat("The second parameter is a String",l_myMethod.getParameterTypes()[0], Matchers.equalTo(String.class));
+
+        assertThat("The second parameter is an array",l_myMethod.getParameterTypes()[1].isArray());
+        assertThat("The Second parameter is an array",l_myMethod.getParameterTypes()[1], Matchers.equalTo(String[].class));
+
+        System.out.println(l_myMethod.getParameterTypes()[1].getComponentType().getTypeName());
+
+        assertThat("We should now have an array of array", l_cc.getArgs()[0], Matchers.instanceOf(String.class));
+
+        System.out.println("arg "+l_cc.getArgs()[0].getClass());
+        System.out.println("arg "+l_cc.getArgs()[1].getClass());
+
+        Object[] newArgs = l_cc.castArgs(l_cc.getArgs(), l_myMethod);
+        assertThat(newArgs, Matchers.notNullValue());
+        assertThat("We should now have an array", newArgs[0].getClass(), Matchers.equalTo(String.class));
+
+        assertThat("We should now have an array", newArgs[1].getClass().isArray());
+
+
+        assertThat("We should now have an array of Strings", newArgs[1].getClass().getComponentType(), Matchers.equalTo(String.class));
+
+        assertThat("We should get the correct return value", l_myJavaCall.call("call1"), Matchers.equalTo(5));
+    }
+
+
+    @Test
     public void testMetaIsListToArray() throws NoSuchMethodException {
         JavaCalls l_myJavaCall = new JavaCalls();
 
@@ -2067,25 +2106,5 @@ public class TestFetchCalls {
                 fetchSubjects, Matchers.hasItem("a subject by me complexCallsArray_3"));
 
     }
-
-    @Test
-    public void issue176_callingMethodAcceptingStringAndArray() {
-        JavaCalls l_myJavaCall = new JavaCalls();
-
-        CallContent l_cc1 = new CallContent();
-        l_cc1.setClassName(SimpleStaticMethods.class.getTypeName());
-        l_cc1.setMethodName("methodAcceptingStringAndArray");
-        String[] l_array = new String[]{"value1", "value2"};
-        l_cc1.setArgs(new Object[]{"ASD", l_array});
-
-        l_myJavaCall.getCallContent().put("fetchResults", l_cc1);
-
-        JavaCallResults jcr = l_myJavaCall.submitCalls();
-
-        assertThat("we should have succeeded", jcr.getReturnValues().keySet(), Matchers.containsInAnyOrder("fetchResults"));
-
-
-    }
-
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Found bug when the array is the second argument of the method being called. 
We also felt that the error messages were not clear enough

## Related Issue

Fixes #176 

## How Has This Been Tested?

manual and auttomatic


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
