### PR TITLE
Expose auto-discovered methods as individual MCP tools (hybrid approach)

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -116,9 +116,10 @@ curl -s -X POST http://localhost:8080/mcp \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
 ```
 
-`tools/list` always returns exactly **one tool — `java_call`**. Its `description` contains a
-catalog of all methods discovered from the configured packages. AI agents read that catalog to
-learn which class and method names to place in their `callContent` payloads.
+`tools/list` returns **one tool per auto-discovered method** plus `java_call` (for multi-step
+chains) and `ibs_diagnostics`. AI agents can call individual methods directly by name, or bundle
+multiple steps into a single `java_call` chain when they need to pass live Java objects between
+steps.
 
 ```json
 {
@@ -127,29 +128,28 @@ learn which class and method names to place in their `callContent` payloads.
   "result": {
     "tools": [
       {
-        "name": "java_call",
-        "description": "Generic BridgeService call. Accepts the full /call payload including call chaining, instance methods, environment variables, and timeout. Bundle all operations into one callContent chain so they share a single isolated execution context. State (including authentication) does not persist between separate tool calls.\n\nDiscovered methods (use class/method values in callContent for java_call):\n\nSimpleStaticMethods_methodReturningString\n  class:  com.adobe.campaign.tests.bridge.testdata.one.SimpleStaticMethods\n  method: methodReturningString\n  Returns the success string constant used for testing.\n  args: (none)\n\nSimpleStaticMethods_methodAcceptingStringArgument\n  class:  com.adobe.campaign.tests.bridge.testdata.one.SimpleStaticMethods\n  method: methodAcceptingStringArgument\n  Appends the success suffix to the given string.\n  arg0 (string): the input string\n\n... (further entries for ClassWithLogger methods etc.)",
+        "name": "SimpleStaticMethods_methodReturningString",
+        "description": "Returns the success string constant used for testing.",
+        "inputSchema": { "type": "object", "properties": {} }
+      },
+      {
+        "name": "SimpleStaticMethods_methodAcceptingStringArgument",
+        "description": "Appends the success suffix to the given string.",
         "inputSchema": {
           "type": "object",
-          "required": ["callContent"],
-          "properties": {
-            "callContent": {
-              "type": "object",
-              "description": "Map of call IDs to call definitions.",
-              "additionalProperties": {
-                "type": "object",
-                "required": ["class", "method"],
-                "properties": {
-                  "class":  { "type": "string" },
-                  "method": { "type": "string" },
-                  "args":   { "type": "array"  }
-                }
-              }
-            },
-            "environmentVariables": { "type": "object" },
-            "timeout": { "type": "integer" }
-          }
+          "properties": { "arg0": { "type": "string", "description": "the input string" } },
+          "required": ["arg0"]
         }
+      },
+      {
+        "name": "java_call",
+        "description": "Generic BridgeService call for multi-step chains. ...",
+        "inputSchema": { "type": "object", "required": ["callContent"], "properties": { "callContent": { "..." } } }
+      },
+      {
+        "name": "ibs_diagnostics",
+        "description": "Built-in IBS diagnostic tool. ...",
+        "inputSchema": { "type": "object", "properties": {} }
       }
     ]
   }
@@ -158,8 +158,7 @@ learn which class and method names to place in their `callContent` payloads.
 
 ### Calling tools
 
-All calls go through `java_call`. Use the class and method names from the catalog in
-`callContent`.
+Single-method calls can be made directly by tool name. Multi-step chains go through `java_call`.
 
 **No-argument method:**
 
@@ -256,37 +255,31 @@ curl -s -X POST http://localhost:8080/mcp \
   }'
 ```
 
-### How the method catalog works
+### How method discovery works
 
-`tools/list` returns a single tool — `java_call`. Auto-discovery does not produce separately
-callable tools; instead it builds a **catalog** that is embedded in the `java_call` description.
+`tools/list` exposes each auto-discovered public static method as its own MCP tool, named
+`ClassName_methodName`. Each tool carries its own `inputSchema` (parameters named `arg0`,
+`arg1`, …) and a Javadoc-sourced description. The list is rebuilt every time the server starts,
+so it stays in sync with the Java library automatically.
 
-When an AI agent calls `tools/list` it reads the catalog to learn which class and method names
-exist, then constructs the appropriate `callContent` payload and calls `java_call`. The catalog is
-rebuilt every time the server starts, so it stays in sync with the Java library automatically.
+AI agents can call individual methods directly for single stateless reads, or bundle multiple
+steps into a `java_call` chain when they need to pass live Java objects between steps.
 
-**Why not separate tools per method?**
+**When to use individual tools vs `java_call`:**
 
-Separate tools per method force the AI to make one HTTP round-trip per method call and lose
-execution context between calls. With `java_call`, any number of steps can be bundled into one
-request inside a single isolated class loader — enabling call chaining, where the return value
-of step N is passed directly to step N+1 as a live Java object (not serialized JSON). This is
-essential for scenarios involving authentication, object creation, or anything with mutable state.
+| Scenario | Use |
+|---|---|
+| Single stateless read | Individual tool (`ClassName_methodName`) |
+| Step B needs the Java object returned by step A | `java_call` with call chain |
+| Overloaded method (same parameter count) | `java_call` |
+| Instance method or constructor | `java_call` |
 
-The catalog format in the description for each entry is:
+**Individual tools are for discovery and stateless calls.** Each tool call runs in a fresh
+isolated class loader. Complex Java objects (e.g. `List<MimeMessage>`) do not survive the JSON
+serialization round-trip between separate calls — they must be chained inside a single `java_call`.
 
-```
-ClassName_methodName
-  class:  com.example.package.ClassName
-  method: methodName
-  <Javadoc description>
-  arg0 (type): <param description>
-  arg1 (type): <param description>
-```
-
-**Project skills and `CLAUDE.md`** can reference catalog entries by class/method name to give the
-AI more context about when and how to use each one. For per-user auth or multi-step flows, the
-skill prepends an auth step to the `java_call` callContent chain.
+**Project skills and `CLAUDE.md`** can annotate methods with additional context (auth patterns,
+known FQ class names, multi-step flow recipes) to help the AI select the right tool and chain.
 
 ---
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -257,6 +257,28 @@ curl -s -X POST http://localhost:8080/mcp \
 
 ### How method discovery works
 
+```mermaid
+flowchart LR
+    subgraph startup["Startup"]
+        P["Configured packages\n(IBS.CLASSLOADER.STATIC\n.INTEGRITY.PACKAGES)"] --> D["MCPToolDiscovery\n(public static methods)"]
+        D --> TL["tools/list\n──────────────────\nClassName_method₁\nClassName_method₂  …\njava_call\nibs_diagnostics"]
+    end
+
+    subgraph call["Per call — tools/call"]
+        A["AI Agent"]
+        IT["handleIndividual\nToolCall()"]
+        JC["handleJavaCall()"]
+        PC["PRECHAIN\n(if configured)"]
+        CL["Isolated ClassLoader\n(fresh per call)"]
+        R["Result"]
+
+        A -->|"ClassName_methodN\n{ arg0, arg1, … }"| IT
+        A -->|"java_call\n{ callContent: {…} }"| JC
+        IT -->|"synthetic single-step\ncallContent"| JC
+        JC --> PC --> CL --> R
+    end
+```
+
 `tools/list` exposes each auto-discovered public static method as its own MCP tool, named
 `ClassName_methodName`. Each tool carries its own `inputSchema` (parameters named `arg0`,
 `arg1`, …) and a Javadoc-sourced description. The list is rebuilt every time the server starts,

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/MCPRequestHandler.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/MCPRequestHandler.java
@@ -25,12 +25,11 @@ import java.util.stream.Collectors;
  *
  * Implements the MCP (Model Context Protocol) Streamable HTTP transport for tool access:
  * - initialize    : MCP handshake
- * - tools/list    : returns a single {@code java_call} tool whose description embeds a
- *                   catalog of auto-discovered methods
- * - tools/call    : invokes the {@code java_call} tool, which accepts arbitrary BridgeService
- *                   call chains; auto-discovered methods are not directly callable as
- *                   separate MCP tools — the catalog in the description tells the LLM which
- *                   class and method names to place in the callContent payload
+ * - tools/list    : returns one tool per auto-discovered method, plus {@code java_call}
+ *                   and {@code ibs_diagnostics}
+ * - tools/call    : routes to the matching individual tool (single stateless call),
+ *                   {@code java_call} (multi-step chain, overloaded/instance methods),
+ *                   or {@code ibs_diagnostics}
  *
  * Tool discovery is performed once at construction time using IBS.CLASSLOADER.STATIC.INTEGRITY.PACKAGES.
  */
@@ -72,41 +71,53 @@ public class MCPRequestHandler {
     private final ObjectMapper mapper = new ObjectMapper();
     private final List<Map<String, Object>> toolList;
     private final int discoveredToolCount;
+    private final Map<String, Method> methodRegistry;
+    private final Map<String, Map<String, Object>> toolDefinitions;
 
     /**
      * Constructs the handler, performs tool discovery from IBS.CLASSLOADER.STATIC.INTEGRITY.PACKAGES,
-     * and builds a single {@code java_call} tool whose description embeds a catalog of all
-     * discovered methods.
+     * and exposes each discovered method as its own MCP tool in addition to {@code java_call}
+     * and {@code ibs_diagnostics}.
      */
     public MCPRequestHandler() {
         MCPToolDiscovery.DiscoveryResult discovery = MCPToolDiscovery.discoverTools(
                 ConfigValueHandlerIBS.STATIC_INTEGRITY_PACKAGES.fetchValue());
-        String catalog = buildCatalog(discovery.tools, discovery.methodRegistry);
         this.discoveredToolCount = discovery.methodRegistry.size();
+        this.methodRegistry = Collections.unmodifiableMap(new LinkedHashMap<>(discovery.methodRegistry));
 
+        Map<String, Map<String, Object>> defs = new LinkedHashMap<>();
         List<Map<String, Object>> tools = new ArrayList<>();
-        try {
-            Map<String, Object> javaCallTool = new LinkedHashMap<>();
-            javaCallTool.put("name", JAVA_CALL_TOOL_NAME);
-            javaCallTool.put("description", buildJavaCallDescription(catalog));
-            javaCallTool.put("inputSchema", mapper.readValue(JAVA_CALL_TOOL_SCHEMA, Map.class));
-            tools.add(javaCallTool);
 
-            Map<String, Object> diagnosticsTool = new LinkedHashMap<>();
-            diagnosticsTool.put("name", DIAGNOSTICS_TOOL_NAME);
-            diagnosticsTool.put("description",
+        for (Map<String, Object> lt_toolDef : discovery.tools) {
+            String lt_name = (String) lt_toolDef.get("name");
+            defs.put(lt_name, lt_toolDef);
+            tools.add(lt_toolDef);
+        }
+        this.toolDefinitions = Collections.unmodifiableMap(defs);
+
+        try {
+            Map<String, Object> l_javaCallTool = new LinkedHashMap<>();
+            l_javaCallTool.put("name", JAVA_CALL_TOOL_NAME);
+            l_javaCallTool.put("description", buildJavaCallDescription());
+            l_javaCallTool.put("inputSchema", mapper.readValue(JAVA_CALL_TOOL_SCHEMA, Map.class));
+            tools.add(l_javaCallTool);
+
+            Map<String, Object> l_diagnosticsTool = new LinkedHashMap<>();
+            l_diagnosticsTool.put("name", DIAGNOSTICS_TOOL_NAME);
+            l_diagnosticsTool.put("description",
                     "Built-in IBS diagnostic tool. Returns IBS version, MCP config state, "
                     + "and header classification: secret key names (values suppressed), "
                     + "env-var key+value pairs (decoded: prefix stripped, uppercased), "
                     + "and regular header count. No arguments required. "
                     + "Does not depend on HOST packages — always available.");
-            diagnosticsTool.put("inputSchema", mapper.readValue(DIAGNOSTICS_TOOL_SCHEMA, Map.class));
-            tools.add(diagnosticsTool);
+            l_diagnosticsTool.put("inputSchema", mapper.readValue(DIAGNOSTICS_TOOL_SCHEMA, Map.class));
+            tools.add(l_diagnosticsTool);
         } catch (JsonProcessingException e) {
             log.error("Failed to parse tool schema — one or more tools will not be available.", e);
         }
         this.toolList = Collections.unmodifiableList(tools);
-        log.info("MCPRequestHandler ready: {} method(s) in catalog via java_call.", discoveredToolCount);
+        log.info("MCPRequestHandler ready: {} individual tool(s) + java_call + ibs_diagnostics.",
+                discoveredToolCount);
     }
 
     /**
@@ -199,80 +210,24 @@ public class MCPRequestHandler {
             return handleDiagnostics(id, headers);
         }
 
+        if (methodRegistry.containsKey(toolName)) {
+            return handleIndividualToolCall(id, toolName, arguments, headers);
+        }
+
         return buildCallToolResult(id, "Unknown tool: " + toolName
-                + ". The only executable tool is java_call — use the class and method from its description catalog.",
+                + ". Use tools/list to see all available tools.",
                 true);
     }
 
-    /**
-     * Builds the catalog text embedded in the java_call tool description. Each discovered
-     * method is listed with its fully qualified class name, method name, Javadoc description,
-     * and argument list so the LLM can construct the correct callContent payload.
-     */
-    private String buildCatalog(List<Map<String, Object>> tools, Map<String, Method> methodRegistry) {
-        if (methodRegistry.isEmpty()) {
-            return "";
-        }
-        StringBuilder sb = new StringBuilder();
-        sb.append("Discovered methods (use class/method values in callContent for java_call):\n\n");
-        for (Map.Entry<String, Method> entry : methodRegistry.entrySet()) {
-            String toolName = entry.getKey();
-            Method method = entry.getValue();
-
-            sb.append(toolName).append("\n");
-            sb.append("  class:  ").append(method.getDeclaringClass().getName()).append("\n");
-            sb.append("  method: ").append(method.getName()).append("\n");
-
-            Map<String, Object> toolDef = tools.stream()
-                    .filter(t -> toolName.equals(t.get("name")))
-                    .findFirst()
-                    .orElse(null);
-
-            if (toolDef != null) {
-                String desc = (String) toolDef.get("description");
-                if (desc != null && !desc.isEmpty()) {
-                    sb.append("  ").append(desc).append("\n");
-                }
-
-                @SuppressWarnings("unchecked")
-                Map<String, Object> schema = (Map<String, Object>) toolDef.get("inputSchema");
-                if (schema != null) {
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> props = (Map<String, Object>) schema.get("properties");
-                    if (props == null || props.isEmpty()) {
-                        sb.append("  args: (none)\n");
-                    } else {
-                        for (Map.Entry<String, Object> propEntry : props.entrySet()) {
-                            @SuppressWarnings("unchecked")
-                            Map<String, Object> propSchema = (Map<String, Object>) propEntry.getValue();
-                            String type = (String) propSchema.get("type");
-                            String propDesc = (String) propSchema.get("description");
-                            sb.append("  ").append(propEntry.getKey())
-                                    .append(" (").append(type).append("): ")
-                                    .append(propDesc).append("\n");
-                        }
-                    }
-                }
-            }
-            sb.append("\n");
-        }
-        return sb.toString().trim();
-    }
-
-    /**
-     * Assembles the full java_call tool description, combining the base usage guidance with
-     * the auto-discovered method catalog (when methods are found in the configured packages).
-     */
-    private String buildJavaCallDescription(String catalog) {
-        String base = "Generic BridgeService call. Accepts the full /call payload including call chaining, "
-                + "instance methods, environment variables, and timeout. "
-                + "Bundle all operations into one callContent chain so they share a single isolated "
-                + "execution context. State (including authentication) does not persist between "
-                + "separate tool calls.";
-        if (catalog.isEmpty()) {
-            return base;
-        }
-        return base + "\n\n" + catalog;
+    private String buildJavaCallDescription() {
+        return "Generic BridgeService call for multi-step chains. "
+                + "Accepts the full /call payload including call chaining, instance methods, "
+                + "environment variables, and timeout. Bundle all operations into one callContent "
+                + "chain so they share a single isolated execution context. "
+                + "State (including authentication) does not persist between separate tool calls.\n\n"
+                + "Use individual tools in tools/list for single stateless method calls. "
+                + "Use java_call when step B needs the Java object returned by step A, "
+                + "or for overloaded/instance methods not available as individual tools.";
     }
 
     /**
@@ -405,6 +360,36 @@ public class MCPRequestHandler {
         } catch (Exception e) {
             log.error("ibs_diagnostics tool failed: {}", e.getMessage(), e);
             return buildCallToolResult(id, exceptionToErrorPayload(e), true);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private String handleIndividualToolCall(Object in_id, String in_toolName,
+            Map<String, Object> in_arguments, Map<String, String> in_headers) {
+        try {
+            Method l_method = methodRegistry.get(in_toolName);
+            Map<String, Object> l_toolDef = toolDefinitions.get(in_toolName);
+            Map<String, Object> l_schema = (Map<String, Object>) l_toolDef.get("inputSchema");
+            List<String> l_required = (List<String>) l_schema.getOrDefault("required",
+                    Collections.emptyList());
+
+            List<Object> l_args = new ArrayList<>();
+            for (String lt_paramName : l_required) {
+                l_args.add(in_arguments.get(lt_paramName));
+            }
+
+            Map<String, Object> l_callEntry = new LinkedHashMap<>();
+            l_callEntry.put("class", l_method.getDeclaringClass().getName());
+            l_callEntry.put("method", l_method.getName());
+            l_callEntry.put("args", l_args);
+
+            Map<String, Object> l_syntheticArgs = new LinkedHashMap<>();
+            l_syntheticArgs.put("callContent", Collections.singletonMap("result", l_callEntry));
+
+            return handleJavaCall(in_id, l_syntheticArgs, in_headers);
+        } catch (Exception e) {
+            log.debug("Individual tool call failed for '{}': {}", in_toolName, e.getMessage());
+            return buildCallToolResult(in_id, exceptionToErrorPayload(e), true);
         }
     }
 

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/MCPRequestHandler.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/MCPRequestHandler.java
@@ -42,31 +42,57 @@ public class MCPRequestHandler {
     private static final String DIAGNOSTICS_TOOL_NAME = "ibs_diagnostics";
     static final String PRECHAIN_HEADER = "ibs-prechain";
 
-    private static final String JAVA_CALL_TOOL_SCHEMA = "{"
-            + "\"type\":\"object\","
-            + "\"required\":[\"callContent\"],"
-            + "\"properties\":{"
-            + "\"callContent\":{"
-            + "\"type\":\"object\","
-            + "\"description\":\"Map of call IDs to call definitions. A string arg matching a prior call ID is substituted with that call's result.\","
-            + "\"additionalProperties\":{"
-            + "\"type\":\"object\","
-            + "\"required\":[\"class\",\"method\"],"
-            + "\"properties\":{"
-            + "\"class\":{\"type\":\"string\",\"description\":\"Fully qualified Java class name\"},"
-            + "\"method\":{\"type\":\"string\",\"description\":\"Method name\"},"
-            + "\"args\":{\"type\":\"array\",\"description\":\"Method arguments\"},"
-            + "\"returnType\":{\"type\":\"string\",\"description\":\"Optional expected return type\"}"
-            + "}}},"
-            + "\"environmentVariables\":{\"type\":\"object\",\"description\":\"Key-value pairs injected before execution\"},"
-            + "\"timeout\":{\"type\":\"integer\",\"description\":\"Timeout in milliseconds (0=unlimited, default 10000)\"}"
-            + "}}";
+    private static final Map<String, Object> JAVA_CALL_SCHEMA_MAP = buildJavaCallSchemaMap();
+    private static final Map<String, Object> DIAGNOSTICS_SCHEMA_MAP = buildDiagnosticsSchemaMap();
 
-    private static final String DIAGNOSTICS_TOOL_SCHEMA = "{"
-            + "\"type\":\"object\","
-            + "\"properties\":{},"
-            + "\"required\":[]"
-            + "}";
+    private static Map<String, Object> schemaProp(String in_type, String in_desc) {
+        Map<String, Object> l_p = new LinkedHashMap<>();
+        l_p.put("type", in_type);
+        l_p.put("description", in_desc);
+        return l_p;
+    }
+
+    private static Map<String, Object> buildJavaCallSchemaMap() {
+        Map<String, Object> l_callEntryProps = new LinkedHashMap<>();
+        l_callEntryProps.put("class", schemaProp("string", "Fully qualified Java class name"));
+        l_callEntryProps.put("method", schemaProp("string", "Method name"));
+        l_callEntryProps.put("args", schemaProp("array", "Method arguments"));
+        l_callEntryProps.put("returnType", schemaProp("string", "Optional expected return type"));
+
+        Map<String, Object> l_callEntrySchema = new LinkedHashMap<>();
+        l_callEntrySchema.put("type", "object");
+        l_callEntrySchema.put("required", Arrays.asList("class", "method"));
+        l_callEntrySchema.put("properties", l_callEntryProps);
+
+        Map<String, Object> l_callContentProp = new LinkedHashMap<>();
+        l_callContentProp.put("type", "object");
+        l_callContentProp.put("description",
+                "Map of call IDs to call definitions. A string arg matching a prior call ID is substituted with that call's result.");
+        l_callContentProp.put("additionalProperties", l_callEntrySchema);
+
+        Map<String, Object> l_props = new LinkedHashMap<>();
+        l_props.put("callContent", l_callContentProp);
+        l_props.put("environmentVariables", schemaProp("object", "Key-value pairs injected before execution"));
+
+        Map<String, Object> l_timeoutProp = new LinkedHashMap<>();
+        l_timeoutProp.put("type", "integer");
+        l_timeoutProp.put("description", "Timeout in milliseconds (0=unlimited, default 10000)");
+        l_props.put("timeout", l_timeoutProp);
+
+        Map<String, Object> l_schema = new LinkedHashMap<>();
+        l_schema.put("type", "object");
+        l_schema.put("required", Collections.singletonList("callContent"));
+        l_schema.put("properties", l_props);
+        return Collections.unmodifiableMap(l_schema);
+    }
+
+    private static Map<String, Object> buildDiagnosticsSchemaMap() {
+        Map<String, Object> l_schema = new LinkedHashMap<>();
+        l_schema.put("type", "object");
+        l_schema.put("properties", new LinkedHashMap<>());
+        l_schema.put("required", Collections.emptyList());
+        return Collections.unmodifiableMap(l_schema);
+    }
 
     private final ObjectMapper mapper = new ObjectMapper();
     private final List<Map<String, Object>> toolList;
@@ -95,26 +121,22 @@ public class MCPRequestHandler {
         }
         this.toolDefinitions = Collections.unmodifiableMap(defs);
 
-        try {
-            Map<String, Object> l_javaCallTool = new LinkedHashMap<>();
-            l_javaCallTool.put("name", JAVA_CALL_TOOL_NAME);
-            l_javaCallTool.put("description", buildJavaCallDescription());
-            l_javaCallTool.put("inputSchema", mapper.readValue(JAVA_CALL_TOOL_SCHEMA, Map.class));
-            tools.add(l_javaCallTool);
+        Map<String, Object> l_javaCallTool = new LinkedHashMap<>();
+        l_javaCallTool.put("name", JAVA_CALL_TOOL_NAME);
+        l_javaCallTool.put("description", buildJavaCallDescription());
+        l_javaCallTool.put("inputSchema", JAVA_CALL_SCHEMA_MAP);
+        tools.add(l_javaCallTool);
 
-            Map<String, Object> l_diagnosticsTool = new LinkedHashMap<>();
-            l_diagnosticsTool.put("name", DIAGNOSTICS_TOOL_NAME);
-            l_diagnosticsTool.put("description",
-                    "Built-in IBS diagnostic tool. Returns IBS version, MCP config state, "
-                    + "and header classification: secret key names (values suppressed), "
-                    + "env-var key+value pairs (decoded: prefix stripped, uppercased), "
-                    + "and regular header count. No arguments required. "
-                    + "Does not depend on HOST packages — always available.");
-            l_diagnosticsTool.put("inputSchema", mapper.readValue(DIAGNOSTICS_TOOL_SCHEMA, Map.class));
-            tools.add(l_diagnosticsTool);
-        } catch (JsonProcessingException e) {
-            log.error("Failed to parse tool schema — one or more tools will not be available.", e);
-        }
+        Map<String, Object> l_diagnosticsTool = new LinkedHashMap<>();
+        l_diagnosticsTool.put("name", DIAGNOSTICS_TOOL_NAME);
+        l_diagnosticsTool.put("description",
+                "Built-in IBS diagnostic tool. Returns IBS version, MCP config state, "
+                + "and header classification: secret key names (values suppressed), "
+                + "env-var key+value pairs (decoded: prefix stripped, uppercased), "
+                + "and regular header count. No arguments required. "
+                + "Does not depend on HOST packages — always available.");
+        l_diagnosticsTool.put("inputSchema", DIAGNOSTICS_SCHEMA_MAP);
+        tools.add(l_diagnosticsTool);
         this.toolList = Collections.unmodifiableList(tools);
         log.info("MCPRequestHandler ready: {} individual tool(s) + java_call + ibs_diagnostics.",
                 discoveredToolCount);
@@ -366,31 +388,26 @@ public class MCPRequestHandler {
     @SuppressWarnings("unchecked")
     private String handleIndividualToolCall(Object in_id, String in_toolName,
             Map<String, Object> in_arguments, Map<String, String> in_headers) {
-        try {
-            Method l_method = methodRegistry.get(in_toolName);
-            Map<String, Object> l_toolDef = toolDefinitions.get(in_toolName);
-            Map<String, Object> l_schema = (Map<String, Object>) l_toolDef.get("inputSchema");
-            List<String> l_required = (List<String>) l_schema.getOrDefault("required",
-                    Collections.emptyList());
+        Method l_method = methodRegistry.get(in_toolName);
+        Map<String, Object> l_toolDef = toolDefinitions.get(in_toolName);
+        Map<String, Object> l_schema = (Map<String, Object>) l_toolDef.get("inputSchema");
+        List<String> l_required = (List<String>) l_schema.getOrDefault("required",
+                Collections.emptyList());
 
-            List<Object> l_args = new ArrayList<>();
-            for (String lt_paramName : l_required) {
-                l_args.add(in_arguments.get(lt_paramName));
-            }
-
-            Map<String, Object> l_callEntry = new LinkedHashMap<>();
-            l_callEntry.put("class", l_method.getDeclaringClass().getName());
-            l_callEntry.put("method", l_method.getName());
-            l_callEntry.put("args", l_args);
-
-            Map<String, Object> l_syntheticArgs = new LinkedHashMap<>();
-            l_syntheticArgs.put("callContent", Collections.singletonMap("result", l_callEntry));
-
-            return handleJavaCall(in_id, l_syntheticArgs, in_headers);
-        } catch (Exception e) {
-            log.debug("Individual tool call failed for '{}': {}", in_toolName, e.getMessage());
-            return buildCallToolResult(in_id, exceptionToErrorPayload(e), true);
+        List<Object> l_args = new ArrayList<>();
+        for (String lt_paramName : l_required) {
+            l_args.add(in_arguments.get(lt_paramName));
         }
+
+        Map<String, Object> l_callEntry = new LinkedHashMap<>();
+        l_callEntry.put("class", l_method.getDeclaringClass().getName());
+        l_callEntry.put("method", l_method.getName());
+        l_callEntry.put("args", l_args);
+
+        Map<String, Object> l_syntheticArgs = new LinkedHashMap<>();
+        l_syntheticArgs.put("callContent", Collections.singletonMap("result", l_callEntry));
+
+        return handleJavaCall(in_id, l_syntheticArgs, in_headers);
     }
 
     private String buildResult(Object id, Object result) {

--- a/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/MCPBridgeServerTest.java
+++ b/integroBridgeService/src/test/java/com/adobe/campaign/tests/bridge/service/MCPBridgeServerTest.java
@@ -79,8 +79,6 @@ public class MCPBridgeServerTest {
 
     @Test(groups = "MCP")
     public void testToolsList_returnsDiscoveredTools() {
-        // Only java_call is a callable tool; the catalog of discovered methods is embedded
-        // in its description so the LLM can construct the right callContent payload.
         given()
                 .contentType(CONTENT_TYPE_JSON)
                 .body("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}")
@@ -88,10 +86,8 @@ public class MCPBridgeServerTest {
                 .post(MCP_ENDPOINT)
         .then()
                 .statusCode(200)
-                .body("result.tools", hasSize(2))
-                .body("result.tools.name", hasItem("java_call"))
-                .body("result.tools.find { it.name == 'java_call' }.description",
-                        containsString("SimpleStaticMethods_methodReturningString"));
+                .body("result.tools.name", hasItems("java_call", "ibs_diagnostics"))
+                .body("result.tools.name", hasItem("SimpleStaticMethods_methodReturningString"));
     }
 
     @Test(groups = "MCP")
@@ -110,7 +106,7 @@ public class MCPBridgeServerTest {
 
     @Test(groups = "MCP")
     public void testToolsList_descriptionComesFromJavadoc() {
-        // The catalog entry for methodReturningString uses its Javadoc text, not the
+        // The individual tool for methodReturningString uses its Javadoc text, not the
         // fallback "Calls com.example.MyClass.methodName()" string.
         given()
                 .contentType(CONTENT_TYPE_JSON)
@@ -119,30 +115,28 @@ public class MCPBridgeServerTest {
                 .post(MCP_ENDPOINT)
         .then()
                 .statusCode(200)
-                .body("result.tools.find { it.name == 'java_call' }.description",
+                .body("result.tools.find { it.name == 'SimpleStaticMethods_methodReturningString' }.description",
                         containsString("success string"));
     }
 
     @Test(groups = "MCP")
     public void testToolsList_noArgToolHasEmptyProperties() {
-        Response resp = given()
+        given()
                 .contentType(CONTENT_TYPE_JSON)
                 .body("{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/list\",\"params\":{}}")
         .when()
                 .post(MCP_ENDPOINT)
         .then()
                 .statusCode(200)
-                .extract().response();
-
-        // methodReturningString is in the catalog — its entry must appear in java_call description
-        String desc = resp.path("result.tools.find { it.name == 'java_call' }.description");
-        assertThat(desc, containsString("SimpleStaticMethods_methodReturningString"));
+                .body("result.tools.name", hasItem("SimpleStaticMethods_methodReturningString"))
+                .body("result.tools.find { it.name == 'SimpleStaticMethods_methodReturningString' }.inputSchema.required",
+                        nullValue());
     }
 
     @Test(groups = "MCP")
     public void testToolsList_undocumentedMethodExcluded() {
         // EnvironmentVariableHandler methods have no Javadoc — must be absent from the
-        // catalog (IBS.MCP.REQUIRE_JAVADOC defaults to true).
+        // tools list (IBS.MCP.REQUIRE_JAVADOC defaults to true).
         given()
                 .contentType(CONTENT_TYPE_JSON)
                 .body("{\"jsonrpc\":\"2.0\",\"id\":13,\"method\":\"tools/list\",\"params\":{}}")
@@ -150,11 +144,9 @@ public class MCPBridgeServerTest {
                 .post(MCP_ENDPOINT)
         .then()
                 .statusCode(200)
-                .body("result.tools", hasSize(2))
-                .body("result.tools.find { it.name == 'java_call' }.description",
-                        not(containsString("EnvironmentVariableHandler_getCacheProperty")))
-                .body("result.tools.find { it.name == 'java_call' }.description",
-                        not(containsString("EnvironmentVariableHandler_setIntegroCache")));
+                .body("result.tools.name", hasItems("java_call", "ibs_diagnostics"))
+                .body("result.tools.name", not(hasItem("EnvironmentVariableHandler_getCacheProperty")))
+                .body("result.tools.name", not(hasItem("EnvironmentVariableHandler_setIntegroCache")));
     }
 
     // ---- ibs_diagnostics tool ----
@@ -168,8 +160,7 @@ public class MCPBridgeServerTest {
                 .post(MCP_ENDPOINT)
         .then()
                 .statusCode(200)
-                .body("result.tools", hasSize(2))
-                .body("result.tools.name", hasItem("ibs_diagnostics"))
+                .body("result.tools.name", hasItems("java_call", "ibs_diagnostics"))
                 .body("result.tools.find { it.name == 'ibs_diagnostics' }.description", notNullValue())
                 .body("result.tools.find { it.name == 'ibs_diagnostics' }.inputSchema", notNullValue());
     }
@@ -902,5 +893,180 @@ public class MCPBridgeServerTest {
                 .post(MCP_ENDPOINT)
         .then()
                 .statusCode(202);
+    }
+
+    // ---- individual tool routing ----
+
+    @Test(groups = "MCP")
+    public void testToolsList_exposesIndividualDiscoveredTools() {
+        given()
+                .contentType(CONTENT_TYPE_JSON)
+                .body("{\"jsonrpc\":\"2.0\",\"id\":100,\"method\":\"tools/list\",\"params\":{}}")
+        .when()
+                .post(MCP_ENDPOINT)
+        .then()
+                .statusCode(200)
+                .body("result.tools.name", hasItem("SimpleStaticMethods_methodReturningString"))
+                .body("result.tools.name", hasItem("SimpleStaticMethods_methodAcceptingStringArgument"))
+                .body("result.tools.find { it.name == 'SimpleStaticMethods_methodReturningString' }.inputSchema",
+                        notNullValue())
+                .body("result.tools.find { it.name == 'SimpleStaticMethods_methodAcceptingStringArgument' }.inputSchema.required",
+                        hasItem("arg0"));
+    }
+
+    @Test(groups = "MCP")
+    public void testIndividualTool_noArgMethod_returnsResult() {
+        given()
+                .contentType(CONTENT_TYPE_JSON)
+                .body("{\"jsonrpc\":\"2.0\",\"id\":101,\"method\":\"tools/call\","
+                        + "\"params\":{\"name\":\"SimpleStaticMethods_methodReturningString\","
+                        + "\"arguments\":{}}}")
+        .when()
+                .post(MCP_ENDPOINT)
+        .then()
+                .statusCode(200)
+                .body("result.isError", equalTo(false))
+                .body("result.content[0].text", containsString("_Success"));
+    }
+
+    @Test(groups = "MCP")
+    public void testIndividualTool_stringArgMethod_returnsResult() {
+        given()
+                .contentType(CONTENT_TYPE_JSON)
+                .body("{\"jsonrpc\":\"2.0\",\"id\":102,\"method\":\"tools/call\","
+                        + "\"params\":{\"name\":\"SimpleStaticMethods_methodAcceptingStringArgument\","
+                        + "\"arguments\":{\"arg0\":\"hello\"}}}")
+        .when()
+                .post(MCP_ENDPOINT)
+        .then()
+                .statusCode(200)
+                .body("result.isError", equalTo(false))
+                .body("result.content[0].text", containsString("hello_Success"));
+    }
+
+    @Test(groups = "MCP")
+    public void testIndividualTool_intArgMethod_returnsResult() {
+        given()
+                .contentType(CONTENT_TYPE_JSON)
+                .body("{\"jsonrpc\":\"2.0\",\"id\":103,\"method\":\"tools/call\","
+                        + "\"params\":{\"name\":\"SimpleStaticMethods_methodAcceptingIntArgument\","
+                        + "\"arguments\":{\"arg0\":42}}}")
+        .when()
+                .post(MCP_ENDPOINT)
+        .then()
+                .statusCode(200)
+                .body("result.isError", equalTo(false))
+                .body("result.content[0].text", containsString("126"));
+    }
+
+    @Test(groups = "MCP")
+    public void testIndividualTool_twoArgMethod_argOrderPreserved() {
+        given()
+                .contentType(CONTENT_TYPE_JSON)
+                .body("{\"jsonrpc\":\"2.0\",\"id\":104,\"method\":\"tools/call\","
+                        + "\"params\":{\"name\":\"SimpleStaticMethods_methodAcceptingTwoArguments\","
+                        + "\"arguments\":{\"arg0\":\"foo\",\"arg1\":\"bar\"}}}")
+        .when()
+                .post(MCP_ENDPOINT)
+        .then()
+                .statusCode(200)
+                .body("result.isError", equalTo(false))
+                .body("result.content[0].text", containsString("foo+bar_Success"));
+    }
+
+    @Test(groups = "MCP")
+    public void testIndividualTool_methodThrowsException_returnsIsError() {
+        given()
+                .contentType(CONTENT_TYPE_JSON)
+                .body("{\"jsonrpc\":\"2.0\",\"id\":105,\"method\":\"tools/call\","
+                        + "\"params\":{\"name\":\"SimpleStaticMethods_methodThrowsException\","
+                        + "\"arguments\":{}}}")
+        .when()
+                .post(MCP_ENDPOINT)
+        .then()
+                .statusCode(200)
+                .body("result.isError", equalTo(true))
+                .body("result.content[0].text", containsString("\"title\""))
+                .body("result.content[0].text", containsString("\"originalException\""));
+    }
+
+    @Test(groups = "MCP")
+    public void testJavaCallDescription_doesNotContainCatalog() {
+        given()
+                .contentType(CONTENT_TYPE_JSON)
+                .body("{\"jsonrpc\":\"2.0\",\"id\":106,\"method\":\"tools/list\",\"params\":{}}")
+        .when()
+                .post(MCP_ENDPOINT)
+        .then()
+                .statusCode(200)
+                .body("result.tools.find { it.name == 'java_call' }.description",
+                        not(containsString("Discovered methods")));
+    }
+
+    @Test(groups = "MCP")
+    public void testIndividualTool_prechainIsApplied() {
+        ConfigValueHandlerIBS.MCP_PRECHAIN.activate(
+                "{\"ibs_pre\":{\"class\":\"com.adobe.campaign.tests.bridge.testdata.one.SimpleStaticMethods\","
+                + "\"method\":\"methodReturningString\",\"args\":[]}}");
+        try {
+            given()
+                    .contentType(CONTENT_TYPE_JSON)
+                    .body("{\"jsonrpc\":\"2.0\",\"id\":107,\"method\":\"tools/call\","
+                            + "\"params\":{\"name\":\"SimpleStaticMethods_methodReturningString\","
+                            + "\"arguments\":{}}}")
+            .when()
+                    .post(MCP_ENDPOINT)
+            .then()
+                    .statusCode(200)
+                    .body("result.isError", equalTo(false))
+                    .body("result.content[0].text", not(containsString("\"ibs_pre\"")))
+                    .body("result.content[0].text", containsString("\"result\""));
+        } finally {
+            ConfigValueHandlerIBS.MCP_PRECHAIN.reset();
+        }
+    }
+
+    // ---- constructor and complex object chaining ----
+
+    @Test(groups = "MCP")
+    public void testToolsList_constructorsNotExposedAsIndividualTools() {
+        given()
+                .contentType(CONTENT_TYPE_JSON)
+                .body("{\"jsonrpc\":\"2.0\",\"id\":108,\"method\":\"tools/list\",\"params\":{}}")
+        .when()
+                .post(MCP_ENDPOINT)
+        .then()
+                .statusCode(200)
+                .body("result.tools.name", not(hasItem("Instantiable_Instantiable")));
+    }
+
+    @Test(groups = "MCP")
+    public void testJavaCall_constructorChain_instantiableThenStaticMethod() {
+        // Constructors are not available as individual tools — use java_call to instantiate
+        // and then pass the result object by reference to a static method in the same chain.
+        String payload = "{\"jsonrpc\":\"2.0\",\"id\":109,\"method\":\"tools/call\","
+                + "\"params\":{\"name\":\"java_call\","
+                + "\"arguments\":{"
+                + "\"callContent\":{"
+                + "\"obj\":{"
+                + "\"class\":\"com.adobe.campaign.tests.bridge.testdata.one.Instantiable\","
+                + "\"method\":\"Instantiable\","
+                + "\"args\":[\"hello\"]"
+                + "},"
+                + "\"fetch\":{"
+                + "\"class\":\"com.adobe.campaign.tests.bridge.testdata.one.StaticType\","
+                + "\"method\":\"fetchInstantiableStringValue\","
+                + "\"args\":[\"obj\"]"
+                + "}}}}}";
+
+        given()
+                .contentType(CONTENT_TYPE_JSON)
+                .body(payload)
+        .when()
+                .post(MCP_ENDPOINT)
+        .then()
+                .statusCode(200)
+                .body("result.isError", equalTo(false))
+                .body("result.content[0].text", containsString("hello"));
     }
 }


### PR DESCRIPTION
Summary:                                                                                                                            
  - Previously all 2000+ auto-discovered methods were embedded as plain text inside java_call's description, exceeding LLM context    
  windows and making method discovery impossible without trial-and-error 404 guessing                                                 
  - Each public static method is now exposed as its own tool in tools/list (ClassName_methodName naming, inputSchema with             
  arg0/arg1/... params) — searchable by keyword via ToolSearch                                                                        
  - Individual tool calls route through handleIndividualToolCall() → handleJavaCall(), so PRECHAIN applies automatically              
  - java_call retained for multi-step chains, overloaded/instance methods, and cases where step B needs the live Java object from step  A                                                                                                                                  
                                                                                                                                      
  Test plan:                                                                                                                          
  - 279 tests pass (mvn -Dtest=MCPBridgeServerTest,MCPToolDiscoveryTest test)                                                         
  - tools/list returns individual tools + java_call + ibs_diagnostics                                                                 
  - Individual tool calls return correct results                                                                                      
  - java_call chaining (including complex object pass-by-reference) still works                                                       
  - PRECHAIN applies to individual tool calls             