### PR TITLE
Update CLAUDE.md: fix web framework reference and Javalin 7 note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ These are managed by `ConfigValueHandlerIBS.java`.
 ## Java & Dependency Notes
 
 - Java 11 (source/target) is required. Do not use APIs introduced after Java 11.
-- Web framework: Spark Java 2.9.4
+- Web framework: Javalin 6.x (Jetty 11, `jakarta.*`). Javalin 7 is not planned — Javalin 6 already supports Java 11–21, so there is no reason to upgrade.
 - JSON: Jackson 2.18.x
 - Logging: Log4j 2 (50MB rotation, 3GB cleanup, 10-day retention per `docs/Technical.md`)
 


### PR DESCRIPTION
## Summary

- Fixes stale "Web framework: Spark Java 2.9.4" reference in CLAUDE.md — the migration to Javalin 6 landed in #43
- Notes that Javalin 7 is not planned since Javalin 6 already covers Java 11–21 (aligns with the `<7.0.0` pin added to `renovate.json`)

## Test plan

- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)