### PR TITLE
Improve Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,39 @@
   "extends": [
     "config:recommended"
   ],
+  "schedule": ["before 9am on Monday"],
   "packageRules": [
     {
       "matchPackagePrefixes": ["io.javalin"],
       "groupName": "javalin",
       "allowedVersions": "<7.0.0"
+    },
+    {
+      "matchPackagePrefixes": ["org.apache.logging.log4j"],
+      "groupName": "log4j"
+    },
+    {
+      "matchPackageNames": [
+        "io.rest-assured:rest-assured",
+        "io.rest-assured:json-path"
+      ],
+      "groupName": "rest-assured"
+    },
+    {
+      "matchPackagePrefixes": ["com.fasterxml.jackson"],
+      "groupName": "jackson"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major-update"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **Schedule**: PRs created before 9am on Mondays — no more mid-week interruptions
- **Grouping**: related deps arrive in one PR instead of many
  - `log4j-core`, `log4j-api`, `log4j-slf4j2-impl` → single PR
  - `rest-assured` + `json-path` → single PR
  - `jackson-*` → single PR
  - all GitHub Actions → single PR
  - `io.javalin:*` already grouped, `<7.0.0` pin retained
- **Automerge patches**: patch bumps merge automatically once CI passes — no review needed
- **Major label**: major version PRs get a `major-update` label for visibility

Fixes the root cause of the javalin/ssl-plugin version mismatch (#44/#45 arriving as separate PRs).

## Test plan

- [ ] Renovate config validation (Renovate validates JSON schema on PR open)
- [ ] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)