### PR TITLE
Fix fat-JAR crash: replace parameterless LogManager.getLogger() calls

### DIFF
--- a/bridgeService-data/src/main/java/com/adobe/campaign/tests/bridge/testdata/one/ClassWithLogger.java
+++ b/bridgeService-data/src/main/java/com/adobe/campaign/tests/bridge/testdata/one/ClassWithLogger.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Random;
 
 public class ClassWithLogger {
-    protected static Logger log = LogManager.getLogger();
+    protected static Logger log = LogManager.getLogger(ClassWithLogger.class);
 
     private static final List<String> countries = Arrays.asList("AT", "AU",
             "CA", "CH", "DE");

--- a/bridgeService-test-injection/pom.xml
+++ b/bridgeService-test-injection/pom.xml
@@ -39,6 +39,9 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
+                    <systemPropertyVariables>
+                        <bridgeservice.root.dir>${project.basedir}/..</bridgeservice.root.dir>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/bridgeService-test-injection/src/test/java/com/adobe/campaign/tests/bridge/dependency/LoggerSafetyTest.java
+++ b/bridgeService-test-injection/src/test/java/com/adobe/campaign/tests/bridge/dependency/LoggerSafetyTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+package com.adobe.campaign.tests.bridge.dependency;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Regression guard: ensures no Java source file calls LogManager.getLogger() without an explicit
+ * class argument. The no-arg form relies on stack-walking which fails in a fat/shaded JAR.
+ */
+public class LoggerSafetyTest {
+
+    private static final Pattern BARE_GET_LOGGER = Pattern.compile("LogManager\\.getLogger\\(\\s*\\)");
+
+    @DataProvider(name = "sourceTrees")
+    public Object[][] sourceTrees() {
+        String l_root = System.getProperty("bridgeservice.root.dir");
+        return new Object[][]{
+                {"integroBridgeService/src/main/java", l_root},
+                {"bridgeService-data/src/main/java", l_root}
+        };
+    }
+
+    @Test(groups = "static-analysis", dataProvider = "sourceTrees")
+    public void testNoParamlessGetLogger(String in_relativeSourceDir, String in_rootDir) throws IOException {
+        Path l_sourceRoot = Paths.get(in_rootDir, in_relativeSourceDir);
+        assertTrue(Files.exists(l_sourceRoot),
+                "Source tree not found: " + l_sourceRoot.toAbsolutePath());
+
+        List<String> l_violations = new ArrayList<>();
+
+        try (Stream<Path> l_files = Files.walk(l_sourceRoot)) {
+            List<Path> l_javaFiles = l_files
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .collect(Collectors.toList());
+
+            for (Path lt_file : l_javaFiles) {
+                List<String> lt_lines = Files.readAllLines(lt_file);
+                for (int i = 0; i < lt_lines.size(); i++) {
+                    if (BARE_GET_LOGGER.matcher(lt_lines.get(i)).find()) {
+                        l_violations.add(l_sourceRoot.relativize(lt_file) + ":" + (i + 1));
+                    }
+                }
+            }
+        }
+
+        assertTrue(l_violations.isEmpty(),
+                "Found parameterless LogManager.getLogger() calls (use getLogger(MyClass.class) instead):\n"
+                        + String.join("\n", l_violations));
+    }
+}

--- a/bridgeService-test-injection/src/test/resources/testng.xml
+++ b/bridgeService-test-injection/src/test/resources/testng.xml
@@ -32,4 +32,14 @@
             <package name="com.adobe.campaign.tests.bridge.dependency" />
         </packages>
     </test>
+    <test verbose="2" name="Static Analysis Tests" time-out="60000">
+        <groups>
+            <run>
+                <include name="static-analysis"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="com.adobe.campaign.tests.bridge.dependency" />
+        </packages>
+    </test>
 </suite>

--- a/integroBridgeService/src/main/java/MainContainer.java
+++ b/integroBridgeService/src/main/java/MainContainer.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class MainContainer {
-    private static final Logger log = LogManager.getLogger();
+    private static final Logger log = LogManager.getLogger(MainContainer.class);
     public static final int PROD_PORT = 443;
     public static final int TEST_PORT = 8080;
 

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/CallContent.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/CallContent.java
@@ -145,7 +145,7 @@ public class CallContent {
 
         Object lr_object;
         try {
-            LogManager.getLogger().debug("Calling  Class: {} and  Method: {} with {} arguments.", this.getClassName(), this.getMethodName(), this.args.length);
+            LogManager.getLogger(CallContent.class).debug("Calling  Class: {} and  Method: {} with {} arguments.", this.getClassName(), this.getMethodName(), this.args.length);
             //Add our package to the classLoader integrity paths
             if (ConfigValueHandlerIBS.INTEGRITY_PACKAGE_INJECTION_MODE.is("semi-manual")) {
 

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/IntegroAPI.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/IntegroAPI.java
@@ -41,7 +41,7 @@ public class IntegroAPI {
     public static final String JAVA_CALL_REF = "call_part";
     public static final String ERROR_BAD_MULTI_PART_REQUEST = "When sending a multi-part request, you need to at least have a payload for the callContent.";
     public static final String STD_UPLOAD_DIR = "upload";
-    private static final Logger log = LogManager.getLogger();
+    private static final Logger log = LogManager.getLogger(IntegroAPI.class);
 
     public static Javalin startServices(int in_port) {
 

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/IntegroBridgeClassLoader.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/IntegroBridgeClassLoader.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import java.util.*;
 
 public class IntegroBridgeClassLoader extends ClassLoader {
-    private static final Logger log = LogManager.getLogger();
+    private static final Logger log = LogManager.getLogger(IntegroBridgeClassLoader.class);
     private Set<String> secretSet;
     private Set<String> headerSet;
     private Map<String, Object> callResultCache;

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/JavaCalls.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/JavaCalls.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 public class JavaCalls {
 
-    private static final Logger log = LogManager.getLogger();
+    private static final Logger log = LogManager.getLogger(JavaCalls.class);
     private Map<String, Assertion> assertions;
     private Long timeout;
     private Map<String, CallContent> callContent;

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/LogManagement.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/LogManagement.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 
 public class LogManagement {
     public static final String STD_CURRENT_STEP = "currentStep";
-    private static final Logger log = LogManager.getLogger();
+    private static final Logger log = LogManager.getLogger(LogManagement.class);
 
     /**
      * Logs the step in the context. it will later be used by the Error Object to generate step info in the error

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/MCPRequestHandler.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/MCPRequestHandler.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  */
 public class MCPRequestHandler {
 
-    private static final Logger log = LogManager.getLogger();
+    private static final Logger log = LogManager.getLogger(MCPRequestHandler.class);
     private static final String JSONRPC_VERSION = "2.0";
     private static final String MCP_PROTOCOL_VERSION = "2024-11-05";
     private static final String JAVA_CALL_TOOL_NAME = "java_call";

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/MCPToolDiscovery.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/MCPToolDiscovery.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
  */
 public class MCPToolDiscovery {
 
-    private static final Logger log = LogManager.getLogger();
+    private static final Logger log = LogManager.getLogger(MCPToolDiscovery.class);
     private static final CommentFormatter COMMENT_FORMATTER = new CommentFormatter();
 
     /**

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/MetaUtils.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/MetaUtils.java
@@ -25,7 +25,7 @@ public class MetaUtils {
             boolean.class, Integer.class, Long.class, Boolean.class, Date.class, Object.class);
     public static final int RECURSION_DEPTH_LIMIT = Integer.parseInt(
             ConfigValueHandlerIBS.DESERIALIZATION_DEPTH_LIMIT.fetchValue());
-    private static final Logger log = LogManager.getLogger();
+    private static final Logger log = LogManager.getLogger(MetaUtils.class);
 
     /**
      * Extracts a possible field name given a method name

--- a/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/utils/ServiceTools.java
+++ b/integroBridgeService/src/main/java/com/adobe/campaign/tests/bridge/service/utils/ServiceTools.java
@@ -66,7 +66,7 @@ public class ServiceTools {
 
     private static int STD_WAIT_BEFORE_INVALIDATE = 5000;
 
-    protected static Logger log = LogManager.getLogger();
+    protected static Logger log = LogManager.getLogger(ServiceTools.class);
 
     public static void setWAIT_BEFORE_INVALIDATE(int in_waitTimeMS) {
         STD_WAIT_BEFORE_INVALIDATE = in_waitTimeMS;


### PR DESCRIPTION
## Summary

Fixes #61

- Replaces all 11 occurrences of `LogManager.getLogger()` (no-arg) with `LogManager.getLogger(TheClass.class)` across `integroBridgeService` and `bridgeService-data`
- Adds a regression guard test in `bridgeService-test-injection` that scans the source trees and fails the build if the no-arg form is reintroduced

## Why

`LogManager.getLogger()` without an explicit class relies on Log4j's `StackLocator` to infer the caller at runtime. This works on a normal classpath but fails in a flat uber-JAR (`integroBridgeService-jar-with-dependencies.jar`) with:

```
ExceptionInInitializerError
Caused by: UnsupportedOperationException: No class provided, and an appropriate one cannot be found.
```

BridgeService never starts when launched as a fat JAR. `mvn exec:java` masks the bug because it uses a classpath layout.

## Files changed

| Area | Change |
|---|---|
| `MainContainer`, `IntegroAPI`, `JavaCalls`, `IntegroBridgeClassLoader`, `LogManagement`, `MetaUtils`, `MCPRequestHandler`, `MCPToolDiscovery`, `ServiceTools`, `CallContent` | `getLogger()` → `getLogger(TheClass.class)` |
| `bridgeService-data/.../ClassWithLogger` | same fix |
| `bridgeService-test-injection/.../LoggerSafetyTest` | new regression guard (group `static-analysis`) |
| `bridgeService-test-injection/pom.xml` | adds `bridgeservice.root.dir` system property for surefire |
| `bridgeService-test-injection/.../testng.xml` | adds `static-analysis` test section |

## Test plan

- [x] `mvn -pl integroBridgeService test` — 295 tests pass
- [x] `mvn -pl bridgeService-test-injection test -Dgroups=static-analysis` — regression guard passes
- [x] `java -jar integroBridgeService/target/integroBridgeService-jar-with-dependencies.jar test` — service starts; `curl http://localhost:8080/test` returns `"overALLSystemState":"All systems up"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)