### PR TITLE
Feature/enrich maven central metadata

### DIFF
--- a/bridgeService-data/pom.xml
+++ b/bridgeService-data/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.adobe.campaign.tests.bridge.testdata</groupId>
     <artifactId>bridgeService-data</artifactId>
-    <name>BridgeService - Test Data</name>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>Concrete Java test classes and demo data used by the BridgeService integration test suite.</description>
     <properties>
         <sonar.skip>true</sonar.skip>

--- a/bridgeService-data/pom.xml
+++ b/bridgeService-data/pom.xml
@@ -14,8 +14,8 @@
 
     <groupId>com.adobe.campaign.tests.bridge.testdata</groupId>
     <artifactId>bridgeService-data</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
-    <description>Test Library for the Bridge Service</description>
+    <name>BridgeService - Test Data</name>
+    <description>Concrete Java test classes and demo data used by the BridgeService integration test suite.</description>
     <properties>
         <sonar.skip>true</sonar.skip>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/integroBridgeService/pom.xml
+++ b/integroBridgeService/pom.xml
@@ -13,9 +13,9 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.campaign.tests.bridge.service</groupId>
     <artifactId>integroBridgeService</artifactId>
-    <description>Bridge Service</description>
+    <description>REST service that invokes Java methods via reflection — enables Cypress, Python, and any HTTP client to call Java libraries without rewriting them. Supports call chaining, Hamcrest assertions, custom class loaders, and MCP tool exposure.</description>
     <packaging>jar</packaging>
-    <name>${project.groupId}:${project.artifactId}</name>
+    <name>BridgeService - REST Service</name>
     <properties>
         <demo.project.mode>test</demo.project.mode>
     </properties>

--- a/integroBridgeService/pom.xml
+++ b/integroBridgeService/pom.xml
@@ -15,7 +15,7 @@
     <artifactId>integroBridgeService</artifactId>
     <description>REST service that invokes Java methods via reflection — enables Cypress, Python, and any HTTP client to call Java libraries without rewriting them. Supports call chaining, Hamcrest assertions, custom class loaders, and MCP tool exposure.</description>
     <packaging>jar</packaging>
-    <name>BridgeService - REST Service</name>
+    <name>${project.groupId}:${project.artifactId}</name>
     <properties>
         <demo.project.mode>test</demo.project.mode>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <version>3.11.5-SNAPSHOT</version>
     <description>BridgeService exposes any Java library as REST endpoints, enabling cross-language test automation and AI agent tool use (MCP). Call Java methods directly from Cypress, Python, or any HTTP client — no rewriting required.</description>
     <packaging>pom</packaging>
-    <name>BridgeService</name>
+    <name>${project.groupId}:${project.artifactId}</name>
     <url>https://github.com/adobe/bridgeService</url>
     <inceptionYear>2022</inceptionYear>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,15 @@
     <groupId>com.adobe.campaign.tests.bridge</groupId>
     <artifactId>parent</artifactId>
     <version>3.11.5-SNAPSHOT</version>
-    <description>Bridge Service Parent Project</description>
+    <description>BridgeService exposes any Java library as REST endpoints, enabling cross-language test automation and AI agent tool use (MCP). Call Java methods directly from Cypress, Python, or any HTTP client — no rewriting required.</description>
     <packaging>pom</packaging>
-    <name>${project.groupId}:${project.artifactId}</name>
+    <name>BridgeService</name>
     <url>https://github.com/adobe/bridgeService</url>
+    <inceptionYear>2022</inceptionYear>
+    <organization>
+        <name>Adobe</name>
+        <url>https://www.adobe.com</url>
+    </organization>
     <licenses>
         <license>
             <name>MIT License</name>
@@ -32,6 +37,14 @@
             <url>https://www.linkedin.com/in/baubakgandomi/</url>
         </developer>
     </developers>
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/adobe/bridgeService/issues</url>
+    </issueManagement>
+    <ciManagement>
+        <system>GitHub Actions</system>
+        <url>https://github.com/adobe/bridgeService/actions</url>
+    </ciManagement>
     <modules>
         <module>integroBridgeService</module>
         <module>bridgeService-data</module>


### PR DESCRIPTION
Closes #64

## Summary

- Add keyword-rich `<description>` to parent POM and both modules so mvnrepository.com search surfaces the project for relevant queries (REST bridge, Java reflection, test automation, MCP)
- Add `<organization>`, `<inceptionYear>`, `<issueManagement>`, and `<ciManagement>` to the parent POM — these fields are displayed on mvnrepository.com and signal project maturity

No functional code changes. Takes effect on the next release to Maven Central.

## Test plan
- [ ] `mvn clean install` passes (no POM schema errors)
- [ ] Verify descriptions look correct after the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)