### PR TITLE
Fix incorrect version references: 3.12 → 3.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following dependency needs to be added to your pom file:
 #### Considerations
 
 Since the BridgeService uses Jetty (via Javalin 6) it is quite possible that there may be conflicts in the project when
-you add this library. BridgeService 3.12+ uses the `jakarta.servlet` namespace (Jetty 11). If your project still uses
+you add this library. BridgeService 3.11.3+ uses the `jakarta.servlet` namespace (Jetty 11). If your project still uses
 `javax.servlet`, you will need to migrate to `jakarta.servlet` or ensure the two are isolated on the classpath.
 
 ### Including your project in the BridgeService
@@ -138,15 +138,15 @@ Legend: ✅ Works &nbsp;|&nbsp; ⚠️ Works with workarounds &nbsp;|&nbsp; ❌ 
 
 | IBS release                    | Exposed Java 8 | Exposed Java 11 | Exposed Java 17 | Exposed Java 21 |
 | ------------------------------ | :------------: | :-------------: | :-------------: | :-------------: |
-| **pre-3.12** (Spark, Java 11)  |      ❌ ¹      |       ✅        |      ⚠️ ²       |      ❌ ³       |
-| **3.12+** (Javalin 6, Java 11) |      ❌ ¹      |       ✅        |       ✅        |       ✅        |
+| **pre-3.11.3** (Spark, Java 11)  |      ❌ ¹      |       ✅        |      ⚠️ ²       |      ❌ ³       |
+| **3.11.3+** (Javalin 6, Java 11) |      ❌ ¹      |       ✅        |       ✅        |       ✅        |
 
 **Aggregator Model** — IBS runs its own JVM and loads the exposed project's classes via reflection.
 
 | IBS release                    | Exposed Java 8 | Exposed Java 11 | Exposed Java 17 | Exposed Java 21 |
 | ------------------------------ | :------------: | :-------------: | :-------------: | :-------------: |
-| **pre-3.12** (Spark, Java 11)  |       ✅       |       ✅        |      ❌ ⁴       |      ❌ ⁴       |
-| **3.12+** (Javalin 6, Java 11) |       ✅       |       ✅        |      ❌ ⁴       |      ❌ ⁴       |
+| **pre-3.11.3** (Spark, Java 11)  |       ✅       |       ✅        |      ❌ ⁴       |      ❌ ⁴       |
+| **3.11.3+** (Javalin 6, Java 11) |       ✅       |       ✅        |      ❌ ⁴       |      ❌ ⁴       |
 
 ¹ Exposed project JVM cannot load IBS bytecode — `UnsupportedClassVersionError`.  
 ² Spark is unofficial on Java 17 and requires `--add-opens` flags.  

--- a/docs/JavaMigration.md
+++ b/docs/JavaMigration.md
@@ -29,7 +29,7 @@ The exposed project's JVM runs IBS. Both the bytecode and the HTTP framework mus
 
 | IBS version + framework | Exposed Java 8 | Exposed Java 11 | Exposed Java 17 | Exposed Java 21 |
 |---|:---:|:---:|:---:|:---:|
-| **Java 11 + Spark** (pre-3.12) | ❌ ¹ | ✅ | ⚠️ ² | ❌ ³ |
+| **Java 11 + Spark** (pre-3.11.3) | ❌ ¹ | ✅ | ⚠️ ² | ❌ ³ |
 | **Java 11 + Javalin 6** *(current)* | ❌ ¹ | ✅ | ✅ ⁴ | ✅ ⁴ |
 | **Java 17 + Spring Boot 3.x** | ❌ ¹ | ❌ ¹ | ✅ ⁴ | ✅ ⁴ |
 | **Java 17 + Javalin 6** | ❌ ¹ | ❌ ¹ | ✅ ⁴ | ✅ ⁴ |
@@ -49,7 +49,7 @@ IBS runs its own JVM and loads the exposed project's classes via reflection. The
 
 | IBS version + framework | Exposed Java 8 | Exposed Java 11 | Exposed Java 17 | Exposed Java 21 |
 |---|:---:|:---:|:---:|:---:|
-| **Java 11 + Spark** (pre-3.12) | ✅ | ✅ | ❌ ⁵ | ❌ ⁵ |
+| **Java 11 + Spark** (pre-3.11.3) | ✅ | ✅ | ❌ ⁵ | ❌ ⁵ |
 | **Java 11 + Javalin 6** *(current)* | ✅ | ✅ | ❌ ⁵ | ❌ ⁵ |
 | **Java 17 + Spring Boot 3.x** | ✅ ⁴ | ✅ ⁴ | ✅ ⁴ | ❌ ⁵ |
 | **Java 17 + Javalin 6** | ✅ ⁴ | ✅ ⁴ | ✅ ⁴ | ❌ ⁵ |
@@ -233,12 +233,12 @@ Java 17 is therefore the perfect stepping stone: it is the Spring Boot 3.x minim
 ## Recommended Migration Path
 
 ```
-                  Java 11 + Spark Java 2.9.4 + Jetty 9.4  [COMPLETE — pre-3.12]
+                  Java 11 + Spark Java 2.9.4 + Jetty 9.4  [COMPLETE — pre-3.11.3]
                   Injection:  Java 11 exposed projects ✔
                   Aggregator: Java 8, 11 exposed projects ✔
        │
        ▼
-Priority 1 (#38)  Java 11 + Javalin 6  ✅ DONE (released 3.12)
+Priority 1 (#38)  Java 11 + Javalin 6  ✅ DONE (released 3.11.3)
                   Replace Spark + Jetty with Javalin 6
                   Fix setAccessible(true) in CallContent.java:171-172
                   Migrate javax.* → jakarta.*


### PR DESCRIPTION
## Summary

The compatibility matrices in `README.md` and `docs/JavaMigration.md` referenced a non-existent version `3.12` for the Spark → Javalin 6 migration. That migration shipped in **3.11.3**.

Replaces all `pre-3.12` / `3.12+` labels with `pre-3.11.3` / `3.11.3+` across both files.

## Test plan
- [ ] Verify compatibility tables still read correctly in rendered Markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)